### PR TITLE
Add `-ww` to all ps commands, use `command` in detailedLookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,6 @@ module.exports.detailedLookup = function (pid, callback){
         wmicQuery('where processid=' + pid, callback);
     } else {
         // OS X/Linux check
-        psQuery('-o pid,args -p ' + pid, callback);
+        psQuery('-o pid,command -p ' + pid, callback);
     }
 };

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports.runCommand = function (cmd, callback) {
 
 function psQuery(args, callback){
 
-    var cmd = 'ps ' + args;
+    var cmd = 'ps -ww ' + args;
     module.exports.runCommand(cmd, function (err, stdout) {
 
         var results = [];


### PR DESCRIPTION
Add `-ww` to all ps commands, and display `command` column in detailedLookup.
